### PR TITLE
Adding missing Hardfault_IRQn definition

### DIFF
--- a/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u1e.h
+++ b/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u1e.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M3 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M3 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M3 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M3 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M3 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M3 System Tick Interrupt       */
 /******  SAM3U1E specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM3U1E Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM3U1E Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM3U1E Real Time Clock (RTC) */
@@ -103,7 +104,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -197,7 +198,7 @@ void USART3_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M3 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M3 Processor and Core Peripherals
  */
 
 #define __CM3_REV              0x0200 /**< SAM3U1E core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u2c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u2c.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M3 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M3 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M3 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M3 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M3 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M3 System Tick Interrupt       */
 /******  SAM3U2C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM3U2C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM3U2C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM3U2C Real Time Clock (RTC) */
@@ -101,7 +102,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -193,7 +194,7 @@ void USART2_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M3 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M3 Processor and Core Peripherals
  */
 
 #define __CM3_REV              0x0200 /**< SAM3U2C core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u2e.h
+++ b/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u2e.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M3 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M3 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M3 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M3 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M3 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M3 System Tick Interrupt       */
 /******  SAM3U2E specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM3U2E Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM3U2E Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM3U2E Real Time Clock (RTC) */
@@ -103,7 +104,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -197,7 +198,7 @@ void USART3_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M3 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M3 Processor and Core Peripherals
  */
 
 #define __CM3_REV              0x0200 /**< SAM3U2E core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u4c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u4c.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M3 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M3 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M3 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M3 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M3 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M3 System Tick Interrupt       */
 /******  SAM3U4C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM3U4C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM3U4C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM3U4C Real Time Clock (RTC) */
@@ -102,7 +103,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -195,7 +196,7 @@ void USART2_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M3 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M3 Processor and Core Peripherals
  */
 
 #define __CM3_REV              0x0200 /**< SAM3U4C core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u4e.h
+++ b/tools/CMSIS_Devices/ATMEL/sam3u/include/sam3u4e.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M3 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M3 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M3 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M3 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M3 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M3 System Tick Interrupt       */
 /******  SAM3U4E specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM3U4E Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM3U4E Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM3U4E Real Time Clock (RTC) */
@@ -104,7 +105,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -199,7 +200,7 @@ void USART3_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M3 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M3 Processor and Core Peripherals
  */
 
 #define __CM3_REV              0x0200 /**< SAM3U4E core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e16c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e16c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */

--- a/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e16e.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e16e.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */

--- a/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e8c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e8c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4E8C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4E8C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4E8C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4E8C Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e8e.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4e/include/sam4e8e.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4E8E specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4E8E Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4E8E Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4E8E Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n16b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n16b.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4N16B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4N16B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4N16B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4N16B Real Time Clock (RTC) */
@@ -100,7 +101,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -193,7 +194,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4N16B core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n16c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n16c.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4N16C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4N16C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4N16C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4N16C Real Time Clock (RTC) */
@@ -105,7 +106,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -203,7 +204,7 @@ void USART2_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4N16C core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n8a.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n8a.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4N8A specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4N8A Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4N8A Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4N8A Real Time Clock (RTC) */
@@ -98,7 +99,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -189,7 +190,7 @@ void USART0_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4N8A core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n8b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n8b.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4N8B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4N8B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4N8B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4N8B Real Time Clock (RTC) */
@@ -100,7 +101,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -193,7 +194,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4N8B core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n8c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4n/include/sam4n8c.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #include <stdint.h>
@@ -58,6 +58,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -66,7 +67,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4N8C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4N8C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4N8C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4N8C Real Time Clock (RTC) */
@@ -105,7 +106,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -203,7 +204,7 @@ void USART2_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4N8C core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/pio/sam4sd32c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/pio/sam4sd32c.h
@@ -112,11 +112,6 @@
 /* ========== Pio definition for ADC peripheral ========== */
 #define PIO_PA17X1_AD0      (1u << 17) /**< \brief Adc signal: AD0 */
 #define PIO_PA18X1_AD1      (1u << 18) /**< \brief Adc signal: AD1 */
-#define PIO_PC13X1_AD10     (1u << 13) /**< \brief Adc signal: AD10 */
-#define PIO_PC15X1_AD11     (1u << 15) /**< \brief Adc signal: AD11 */
-#define PIO_PC12X1_AD12     (1u << 12) /**< \brief Adc signal: AD12 */
-#define PIO_PC29X1_AD13     (1u << 29) /**< \brief Adc signal: AD13 */
-#define PIO_PC30X1_AD14     (1u << 30) /**< \brief Adc signal: AD14 */
 #define PIO_PA19X1_AD2      (1u << 19) /**< \brief Adc signal: AD2/WKUP9 */
 #define PIO_PA19X1_WKUP9    (1u << 19) /**< \brief Adc signal: AD2/WKUP9 */
 #define PIO_PA20X1_AD3      (1u << 20) /**< \brief Adc signal: AD3/WKUP10 */
@@ -130,6 +125,11 @@
 #define PIO_PB3X1_AD7       (1u << 3)  /**< \brief Adc signal: AD7 */
 #define PIO_PA21X1_AD8      (1u << 21) /**< \brief Adc signal: AD8 */
 #define PIO_PA22X1_AD9      (1u << 22) /**< \brief Adc signal: AD9 */
+#define PIO_PC13X1_AD10     (1u << 13) /**< \brief Adc signal: AD10 */
+#define PIO_PC15X1_AD11     (1u << 15) /**< \brief Adc signal: AD11 */
+#define PIO_PC12X1_AD12     (1u << 12) /**< \brief Adc signal: AD12 */
+#define PIO_PC29X1_AD13     (1u << 29) /**< \brief Adc signal: AD13 */
+#define PIO_PC30X1_AD14     (1u << 30) /**< \brief Adc signal: AD14 */
 #define PIO_PA8B_ADTRG      (1u << 8)  /**< \brief Adc signal: ADTRG */
 /* ========== Pio definition for DACC peripheral ========== */
 #define PIO_PB13X1_DAC0     (1u << 13) /**< \brief Dacc signal: DAC0 */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s16b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s16b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S16B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S16B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S16B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S16B Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s16c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s16c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s2a.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s2a.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 #include <stdint.h>
 
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S2A specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S2A Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S2A Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S2A Real Time Clock (RTC) */
@@ -97,7 +98,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -192,7 +193,7 @@ void USART0_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4S2A core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s2b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s2b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S2B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S2B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S2B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S2B Real Time Clock (RTC) */
@@ -100,7 +101,7 @@ typedef struct _DeviceVectors
 {
   /* Stack pointer */
   void* pvStack;
-  
+
   /* Cortex-M handlers */
   void* pfnReset_Handler;
   void* pfnNMI_Handler;
@@ -198,7 +199,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4S2B core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s2c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s2c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S2C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S2C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S2C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S2C Real Time Clock (RTC) */
@@ -206,7 +207,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4S2C core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s4a.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s4a.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S4A specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S4A Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S4A Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S4A Real Time Clock (RTC) */
@@ -192,7 +193,7 @@ void USART0_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4S4A core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s4b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s4b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S4B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S4B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S4B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S4B Real Time Clock (RTC) */
@@ -198,7 +199,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4S4B core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s4c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s4c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S4C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S4C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S4C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S4C Real Time Clock (RTC) */
@@ -206,7 +207,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4S4C core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s8b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s8b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S8B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S8B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S8B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S8B Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s8c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4s8c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4S8C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4S8C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4S8C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4S8C Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sa16b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sa16b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4SA16B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4SA16B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4SA16B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4SA16B Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sa16c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sa16c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4SA16C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4SA16C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4SA16C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4SA16C Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd16b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd16b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4SD16B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4SD16B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4SD16B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4SD16B Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd16c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd16c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4SD16C specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4SD16C Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4SD16C Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4SD16C Real Time Clock (RTC) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd32b.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd32b.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
@@ -64,7 +65,7 @@ typedef enum IRQn
   PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
   SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
 /******  SAM4SD32B specific Interrupt Numbers *********************************/
-  
+
   SUPC_IRQn            =  0, /**<  0 SAM4SD32B Supply Controller (SUPC) */
   RSTC_IRQn            =  1, /**<  1 SAM4SD32B Reset Controller (RSTC) */
   RTC_IRQn             =  2, /**<  2 SAM4SD32B Real Time Clock (RTC) */
@@ -200,7 +201,7 @@ void USART1_Handler     ( void );
 void WDT_Handler        ( void );
 
 /**
- * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
  */
 
 #define __CM4_REV              0x0001 /**< SAM4SD32B core revision number ([15:8] revision number, [7:0] patch number) */

--- a/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd32c.h
+++ b/tools/CMSIS_Devices/ATMEL/sam4s/include/sam4sd32c.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */

--- a/tools/CMSIS_Devices/ATMEL/samg55/include/samg55g19.h
+++ b/tools/CMSIS_Devices/ATMEL/samg55/include/samg55g19.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */

--- a/tools/CMSIS_Devices/ATMEL/samg55/include/samg55j19.h
+++ b/tools/CMSIS_Devices/ATMEL/samg55/include/samg55j19.h
@@ -56,6 +56,7 @@ typedef enum IRQn
 {
 /******  Cortex-M4 Processor Exceptions Numbers ******************************/
   NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn        = -13, /**<  3 HardFault Interrupt                   */
   MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
   BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
   UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */


### PR DESCRIPTION
Some headers coming from Atmel were missing the Hardfault_IRQn definition
