### PR TITLE
[packaging] Improving root mk for full IDE packaging

### DIFF
--- a/module/platform.txt
+++ b/module/platform.txt
@@ -6,7 +6,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=ARM Cortex-M3/M4 (32-bits) Boards
-version=1.0.0
+version=0.1.0
 
 # SAM3/4 compile variables
 # ----------------------


### PR DESCRIPTION
Here we are:
- Module packaging is OK with the expected tar.bz2 and .json files
- win32, win64, linux32, linux64 and osx are managed and os-specific files are auto-magically put at their right place thanks to tar xform
- Travis-CI Job number and build number will be used for the build

Missing at the moment:
- Auto release to github at creation of a tag, needs ruby and travis cli for keys encryption, grrrrrrrrrr
