### PR TITLE
Fix json template

### DIFF
--- a/extras/package_index.json.template
+++ b/extras/package_index.json.template
@@ -27,7 +27,7 @@
             { "name": "Atmel SAM4S-WPIR-RD" },
             { "name": "Atmel SAM4S-Xplained Pro" },
             { "name": "Atmel SAM4E-Xplained Pro" },
-            { "name": "Atmel SAMG55-Xplained Pro" },
+            { "name": "Atmel SAMG55-Xplained Pro" }
           ],
           "toolsDependencies":
           [


### PR DESCRIPTION
Issue : Arduino IDE fail to parse the json file
`Skipping contributed index file /Users/[user]/Library/Arduino15/package_ExperimentalCore-sam_0.2.0_osx_index.json, parsing error occured:com.fasterxml.jackson.databind.JsonMappingException: Unexpected character (']' (code 93)): expected a valueat [Source: java.io.FileInputStream@5d6652d0; line: 31, column: 12] (through reference chain: ContributionsIndex["packages"]->java.util.ArrayList[0]->ContributedPackage["platforms"]->java.util.ArrayList[0]->ContributedPlatform["boards"])`

Fix : removing the extra comma in the boards list
