### PR TITLE
Fix .elf filepath for objcopy command

### DIFF
--- a/module/platform.txt
+++ b/module/platform.txt
@@ -94,7 +94,7 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} {build.linker_flags} "-T{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} --specs=nano.specs --specs=nosys.specs -o "{build.path}/sketch/{build.project_name}.elf" "-L{build.path}" -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} -lm -lgcc "{archive_file_path}" "-l{build.variant}" -Wl,--end-group
 
 ## Create output (bin file)
-recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/sketch/{build.project_name}.bin"
+recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/sketch/{build.project_name}.elf" "{build.path}/sketch/{build.project_name}.bin"
 
 ## Save hex
 recipe.output.tmp_file={build.project_name}.bin


### PR DESCRIPTION
Issue : objcopy command unable to fin .elf file
`"/Users/[user]/Library/Arduino15/packages/arduino/tools/arm-none-eabi-gcc/4.8.3-2014q1/bin/arm-none-eabi-objcopy" -O binary "/var/folders/v6/tj3__g0x16gfgz5vmcx385s80000gn/T/arduino_build_864453/Blink.ino.elf" "/var/folders/v6/tj3__g0x16gfgz5vmcx385s80000gn/T/arduino_build_864453/sketch/Blink.ino.bin"/Users/[user]/Library/Arduino15/packages/arduino/tools/arm-none-eabi-gcc/4.8.3-2014q1/bin/arm-none-eabi-objcopy: '/var/folders/v6/tj3__g0x16gfgz5vmcx385s80000gn/T/arduino_build_864453/Blink.ino.elf': No such fileexit status 1Error compiling for board Atmel SAMG55-Xplained Pro (Programming Port).`

Fix : The .elf file is located in the "sketch" subfolder. Modify objcopy input path.